### PR TITLE
Removed var.existing_net_id from vnet data lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Overlay terraform module can create a an [Azure SQL Server](https://docs.mi
 and associated databases in an optional [SQL Elastic Pool](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-elastic-pool)
 with [DTU purchasing model](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-service-tiers-dtu) or [vCore purchasing model](https://docs.microsoft.com/en-us/azure/azure-sql/database/resource-limits-vcore-elastic-pools)
 only along with [Firewall rules](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-firewall-configure)
-and manage related parameters (Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+and manage related parameters (Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 

--- a/resources.sqlsvr.private.endpoints.tf
+++ b/resources.sqlsvr.private.endpoints.tf
@@ -10,12 +10,19 @@ data "azurerm_virtual_network" "vnet" {
   resource_group_name = local.resource_group_name
 }
 
+data "azurerm_subnet" "snet" {
+  count                = var.enable_private_endpoint && var.existing_private_subnet_name != null ? 1 : 0
+  name                 = var.existing_private_subnet_name
+  virtual_network_name = azurerm_virtual_network.vnet.0.name
+  resource_group_name  = local.resource_group_name
+}
+
 resource "azurerm_private_endpoint" "pep" {
-  count               = var.enable_private_endpoint ? 1 : 0
+  count               = var.enable_private_endpoint && var.existing_private_subnet_name != null ? 1 : 0
   name                = format("%s-private-endpoint", local.primary_server_name)
   location            = local.location
   resource_group_name = local.resource_group_name
-  subnet_id           = var.existing_subnet_id
+  subnet_id           = azurerm_subnet.snet.0.id
   tags                = merge({ "Name" = format("%s", "sqldb-private-endpoint") }, var.add_tags, )
 
   private_service_connection {
@@ -31,7 +38,7 @@ resource "azurerm_private_endpoint" "pep2" {
   name                = format("%s-secondary", "sqldb-private-endpoint")
   location            = local.location
   resource_group_name = local.resource_group_name
-  subnet_id           = var.existing_subnet_id
+  subnet_id           = azurerm_subnet.snet.0.id
   tags                = merge({ "Name" = format("%s", "sqldb-private-endpoint") }, var.tags, )
 
   private_service_connection {

--- a/variables.tf
+++ b/variables.tf
@@ -75,13 +75,13 @@ variable "existing_private_dns_zone" {
   default     = null
 }
 
-variable "virtual_network_name" {
-  description = "Name of the virtual network for the private endpoint"
+variable "existing_private_subnet_name" {
+  description = "Name of the existing private subnet for the private endpoint"
   default     = null
 }
 
-variable "existing_subnet_id" {
-  description = "The resource id of existing subnet"
+variable "virtual_network_name" {
+  description = "Name of the virtual network for the private endpoint"
   default     = null
 }
 


### PR DESCRIPTION
## Describe your changes

1. Removed var.existing_net_id from vnet data lookup
2. Added var.virtual_network_name != null to vnet data lookup
3. Added Failover PE for failover DB
4. Added Data for Existing Subnet in PE
5. Updated README to correct the module for Management Hub

## Issue number

#20 

## Checklist before requesting a review
- [X] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [X] I have executed pre-commit on my machine
- [X] I have passed pr-check on my machine

Thanks for your cooperation!

